### PR TITLE
More complete Result

### DIFF
--- a/example/example.ts
+++ b/example/example.ts
@@ -15,7 +15,7 @@ const generateRandomNum = (): Result<number, string> => {
 const printNumA = () => {
     const res = generateRandomNum();
     
-    if (res.isError) {
+    if (res.isErr()) {
         // return error result to higher function,
         // where error will be resolved
         // or handle it right here, why not?

--- a/src/asyncResult.test.ts
+++ b/src/asyncResult.test.ts
@@ -3,7 +3,6 @@ import { describe, expect, it } from '@jest/globals';
 import { Err, Ok } from './result';
 
 import { AsyncResult, asyncResultify } from './asyncResult';
-import { BaseResultError } from './baseResultError';
 
 describe('Constructors', () => {
     it('Simple Ok async result constructed from Ok result resolves to the provided result', async () => {
@@ -28,7 +27,11 @@ describe('Constructors', () => {
         + 'resolves to Err of the value wrapped with BaseResultError',
         async () => {
             const res = await AsyncResult.fromPromise(Promise.reject(1)).promise;
-            expect(res).toEqual(Err(new BaseResultError(1)));
+            expect(res.err()).toEqual({
+                message: "Caught exotic value (number): 1",
+                name: "BaseError",
+                origValue: 1,
+            });
         }
     );
     it(

--- a/src/asyncResult.test.ts
+++ b/src/asyncResult.test.ts
@@ -2,7 +2,7 @@
 import { describe, expect, it } from '@jest/globals';
 import { Err, Ok } from './result';
 
-import {AsyncResult, asyncResultify} from './asyncResult';
+import { AsyncResult, asyncResultify } from './asyncResult';
 
 describe('Constructors', () => {
     it('Simple Ok async result constructed from Ok result resolves to the provided result', async () => {
@@ -37,7 +37,7 @@ describe('Result methods', () => {
         const asyncRes = AsyncResult.fromResult(Err(1))
         expect(asyncRes.unwrap()).rejects.toThrow();
     });
-    
+
     it('composite test showing all simple result getters', async () => {
         const asyncOkRes = AsyncResult.fromResult(Ok(1))
         expect(await asyncOkRes.ok()).toEqual(1);
@@ -46,7 +46,7 @@ describe('Result methods', () => {
         expect(await asyncOkRes.isErr()).toEqual(false);
         expect(await asyncOkRes.expect('err')).toEqual(1);
         expect(await asyncOkRes.unwrapOr(2)).toEqual(1);
-        expect(await asyncOkRes.unwrapOrElse(() => { 
+        expect(await asyncOkRes.unwrapOrElse(() => {
             expect('to not have been called').toBe(true);
             return 2;
         })).toEqual(1);
@@ -60,10 +60,10 @@ describe('Result methods', () => {
         expect(await asyncErrRes.isErr()).toEqual(true);
         expect(await asyncErrRes.expectErr('err')).toEqual(1);
         expect(await asyncErrRes.unwrapOr(2)).toEqual(2);
-        expect(await asyncErrRes.unwrapOrElse(() => { 
+        expect(await asyncErrRes.unwrapOrElse(() => {
             return 2;
         })).toEqual(2);
-        expect(await asyncErrRes.unwrapOrElse(async () => { 
+        expect(await asyncErrRes.unwrapOrElse(async () => {
             return 2;
         })).toEqual(2);
         expect(asyncErrRes.unwrap()).rejects.toThrow();
@@ -76,7 +76,7 @@ describe('Result methods', () => {
 
 describe('mappers', () => {
     it('inspect gets called with Result value if Result is Ok', async () => {
-        let inspected: number|undefined = undefined;
+        let inspected: number | undefined = undefined;
         await AsyncResult.fromResult(Ok(5)).inspect(val => inspected = val).promise;
         expect(inspected).toEqual(5);
     });
@@ -88,12 +88,12 @@ describe('mappers', () => {
     });
 
     it('inspectErr gets called with Result error if Result is Err', async () => {
-        let inspected: number|undefined = undefined;
+        let inspected: number | undefined = undefined;
         await AsyncResult.fromResult(Err(5)).inspectErr(val => inspected = val).promise;
         expect(inspected).toEqual(5);
     });
 
-    it('inspectErr does not get called if Result is Err', async () => {
+    it('inspectErr does not get called if Result is Ok', async () => {
         await AsyncResult.fromResult(Ok(5)).inspectErr(() => {
             expect('to not have been called').toBe(true);
         }).promise;
@@ -101,13 +101,13 @@ describe('mappers', () => {
 
     it('map runs provided mapper on value of Result, and creates new Result', async () => {
         const res1 = AsyncResult.fromResult(Ok(5))
-        const res2 = res1.map(val => val+1);
+        const res2 = res1.map(val => val + 1);
         expect(await res1.unwrap()).toEqual(5)
         expect(await res2.unwrap()).toEqual(6)
     });
     it('async map runs provided mapper on value of Result, and creates new Result', async () => {
         const res1 = AsyncResult.fromResult(Ok(5))
-        const res2 = res1.map(async val => val+1);
+        const res2 = res1.map(async val => val + 1);
         expect(await res1.unwrap()).toEqual(5)
         expect(await res2.unwrap()).toEqual(6)
     });
@@ -122,13 +122,13 @@ describe('mappers', () => {
 
     it('mapErr runs provided mapper on err of Result, and creates new Result', async () => {
         const res1 = AsyncResult.fromResult(Err(5))
-        const res2 = res1.mapErr(val => val+1);
+        const res2 = res1.mapErr(val => val + 1);
         expect(await res1.unwrapErr()).toEqual(5)
         expect(await res2.unwrapErr()).toEqual(6)
     });
     it('async mapErr runs provided mapper on err of Result, and creates new Result', async () => {
         const res1 = AsyncResult.fromResult(Err(5))
-        const res2 = res1.mapErr(async val => val+1);
+        const res2 = res1.mapErr(async val => val + 1);
         expect(await res1.unwrapErr()).toEqual(5)
         expect(await res2.unwrapErr()).toEqual(6)
     });
@@ -143,7 +143,7 @@ describe('mappers', () => {
 
     it('mapOrElse runs provided mapper on value of Result, and creates new Result', async () => {
         const res1 = AsyncResult.fromResult(Ok(5))
-        const res2 = res1.mapOrElse(val => val+1, () => { 
+        const res2 = res1.mapOrElse(val => val + 1, () => {
             expect('to not have been called').toBe(true)
             return 0;
         });
@@ -152,7 +152,7 @@ describe('mappers', () => {
     });
     it('async mapOrElse runs provided mapper on value of Result, and creates new Result', async () => {
         const res1 = AsyncResult.fromResult(Ok(5))
-        const res2 = res1.mapOrElse(async val => val+1, () => { 
+        const res2 = res1.mapOrElse(async val => val + 1, () => {
             expect('to not have been called').toBe(true)
             return 0;
         });
@@ -162,18 +162,18 @@ describe('mappers', () => {
 
     it('mapOrElse runs provided fallback on err of Result, and creates new Ok Result', async () => {
         const res1 = AsyncResult.fromResult(Err(5))
-        const res2 = res1.mapOrElse(() => { 
+        const res2 = res1.mapOrElse(() => {
             expect('to not have been called').toBe(true)
             return 0;
-        }, err => err+1);
+        }, err => err + 1);
         expect(await res2.unwrap()).toEqual(6)
     });
     it('async mapOrElse runs provided fallback on err of Result, and creates new Ok Result', async () => {
         const res1 = AsyncResult.fromResult(Err(5))
-        const res2 = res1.mapOrElse(() => { 
+        const res2 = res1.mapOrElse(async () => {
             expect('to not have been called').toBe(true)
             return 0;
-        }, err => err+1);
+        }, err => err + 1);
         expect(await res2.unwrap()).toEqual(6)
     });
 });

--- a/src/asyncResult.test.ts
+++ b/src/asyncResult.test.ts
@@ -27,11 +27,7 @@ describe('Constructors', () => {
         + 'resolves to Err of the value wrapped with BaseResultError',
         async () => {
             const res = await AsyncResult.fromPromise(Promise.reject(1)).promise;
-            expect(res.err()).toEqual({
-                message: "Caught exotic value (number): 1",
-                name: "BaseError",
-                origValue: 1,
-            });
+            expect(res.unwrapErr().toString()).toMatchInlineSnapshot(`"BaseError: Caught exotic value (number): 1"`);
         }
     );
     it(

--- a/src/asyncResult.test.ts
+++ b/src/asyncResult.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from '@jest/globals';
 import { Err, Ok } from './result';
 
 import { AsyncResult, asyncResultify } from './asyncResult';
+import { BaseResultError } from './baseResultError';
 
 describe('Constructors', () => {
     it('Simple Ok async result constructed from Ok result resolves to the provided result', async () => {
@@ -22,10 +23,22 @@ describe('Constructors', () => {
         expect(res).toEqual(Ok(1));
     });
 
-    it('Simple Err async result constructed from promise of errRes, resolves to Err result of provided value', async () => {
-        const res = await AsyncResult.fromPromise(Promise.reject(1)).promise;
-        expect(res).toEqual(Err(1));
-    });
+    it(
+        'Simple Err async result constructed from promise of errRes which rejects with non-Error value, '
+        + 'resolves to Err of the value wrapped with BaseResultError',
+        async () => {
+            const res = await AsyncResult.fromPromise(Promise.reject(1)).promise;
+            expect(res).toEqual(Err(new BaseResultError(1)));
+        }
+    );
+    it(
+        'Simple Err async result constructed from promise of errRes which rejects with Error value, '
+        + 'resolves to Err of the value',
+        async () => {
+            const res = await AsyncResult.fromPromise(Promise.reject(new Error('err'))).promise;
+            expect(res).toEqual(Err(new Error('err')));
+        }
+    );
 });
 
 describe('Result methods', () => {

--- a/src/asyncResult.test.ts
+++ b/src/asyncResult.test.ts
@@ -1,0 +1,200 @@
+
+import { describe, expect, it } from '@jest/globals';
+import { Err, Ok } from './result';
+
+import {AsyncResult, asyncResultify} from './asyncResult';
+
+describe('Constructors', () => {
+    it('Simple Ok async result constructed from Ok result resolves to the provided result', async () => {
+        const okRes = Ok(1);
+        const res = await AsyncResult.fromResult(okRes).promise
+        expect(res).toStrictEqual(okRes);
+    });
+
+    it('Simple Err async result constructed from Err result resolves to the provided result', async () => {
+        const errRes = Err(1);
+        const res = await AsyncResult.fromResult(errRes).promise
+        expect(res).toStrictEqual(errRes);
+    });
+
+    it('Simple Ok async result constructed from promise of okRes, resolves to Ok result of provided value', async () => {
+        const res = await AsyncResult.fromPromise(Promise.resolve(1)).promise;
+        expect(res).toEqual(Ok(1));
+    });
+
+    it('Simple Err async result constructed from promise of errRes, resolves to Err result of provided value', async () => {
+        const res = await AsyncResult.fromPromise(Promise.reject(1)).promise;
+        expect(res).toEqual(Err(1));
+    });
+});
+
+describe('Result methods', () => {
+    it('unwrap on Ok resolves to value', async () => {
+        const asyncRes = AsyncResult.fromResult(Ok(1))
+        expect(await asyncRes.unwrap()).toEqual(1);
+    });
+    it('unwrap on Err throws rejects', async () => {
+        const asyncRes = AsyncResult.fromResult(Err(1))
+        expect(asyncRes.unwrap()).rejects.toThrow();
+    });
+    
+    it('composite test showing all simple result getters', async () => {
+        const asyncOkRes = AsyncResult.fromResult(Ok(1))
+        expect(await asyncOkRes.ok()).toEqual(1);
+        expect(await asyncOkRes.err()).toEqual(undefined);
+        expect(await asyncOkRes.isOk()).toEqual(true);
+        expect(await asyncOkRes.isErr()).toEqual(false);
+        expect(await asyncOkRes.expect('err')).toEqual(1);
+        expect(await asyncOkRes.unwrapOr(2)).toEqual(1);
+        expect(await asyncOkRes.unwrapOrElse(() => { 
+            expect('to not have been called').toBe(true);
+            return 2;
+        })).toEqual(1);
+        expect(asyncOkRes.expectErr('err')).rejects.toThrow(Error('err'));
+        expect(asyncOkRes.unwrapErr()).rejects.toThrow();
+
+        const asyncErrRes = AsyncResult.fromResult(Err(1))
+        expect(await asyncErrRes.ok()).toEqual(undefined);
+        expect(await asyncErrRes.err()).toEqual(1);
+        expect(await asyncErrRes.isOk()).toEqual(false);
+        expect(await asyncErrRes.isErr()).toEqual(true);
+        expect(await asyncErrRes.expectErr('err')).toEqual(1);
+        expect(await asyncErrRes.unwrapOr(2)).toEqual(2);
+        expect(await asyncErrRes.unwrapOrElse(() => { 
+            return 2;
+        })).toEqual(2);
+        expect(await asyncErrRes.unwrapOrElse(async () => { 
+            return 2;
+        })).toEqual(2);
+        expect(asyncErrRes.unwrap()).rejects.toThrow();
+        expect(asyncErrRes.expect('err')).rejects.toThrowErrorMatchingInlineSnapshot(`
+"err
+> Original error is: 1"
+`);
+    });
+});
+
+describe('mappers', () => {
+    it('inspect gets called with Result value if Result is Ok', async () => {
+        let inspected: number|undefined = undefined;
+        await AsyncResult.fromResult(Ok(5)).inspect(val => inspected = val).promise;
+        expect(inspected).toEqual(5);
+    });
+
+    it('inspect does not get called if Result is Err', async () => {
+        await AsyncResult.fromResult(Err(5)).inspect(() => {
+            expect('to not have been called').toBe(true);
+        }).promise;
+    });
+
+    it('inspectErr gets called with Result error if Result is Err', async () => {
+        let inspected: number|undefined = undefined;
+        await AsyncResult.fromResult(Err(5)).inspectErr(val => inspected = val).promise;
+        expect(inspected).toEqual(5);
+    });
+
+    it('inspectErr does not get called if Result is Err', async () => {
+        await AsyncResult.fromResult(Ok(5)).inspectErr(() => {
+            expect('to not have been called').toBe(true);
+        }).promise;
+    });
+
+    it('map runs provided mapper on value of Result, and creates new Result', async () => {
+        const res1 = AsyncResult.fromResult(Ok(5))
+        const res2 = res1.map(val => val+1);
+        expect(await res1.unwrap()).toEqual(5)
+        expect(await res2.unwrap()).toEqual(6)
+    });
+    it('async map runs provided mapper on value of Result, and creates new Result', async () => {
+        const res1 = AsyncResult.fromResult(Ok(5))
+        const res2 = res1.map(async val => val+1);
+        expect(await res1.unwrap()).toEqual(5)
+        expect(await res2.unwrap()).toEqual(6)
+    });
+
+    it('map does not get run on Err', async () => {
+        const res1 = AsyncResult.fromResult(Err(5))
+        const res2 = res1.map(() => {
+            expect('to not have been called').toBe(true);
+        });
+        expect(await res2.unwrapErr()).toEqual(5)
+    });
+
+    it('mapErr runs provided mapper on err of Result, and creates new Result', async () => {
+        const res1 = AsyncResult.fromResult(Err(5))
+        const res2 = res1.mapErr(val => val+1);
+        expect(await res1.unwrapErr()).toEqual(5)
+        expect(await res2.unwrapErr()).toEqual(6)
+    });
+    it('async mapErr runs provided mapper on err of Result, and creates new Result', async () => {
+        const res1 = AsyncResult.fromResult(Err(5))
+        const res2 = res1.mapErr(async val => val+1);
+        expect(await res1.unwrapErr()).toEqual(5)
+        expect(await res2.unwrapErr()).toEqual(6)
+    });
+
+    it('mapErr does not get run on Ok', async () => {
+        const res1 = AsyncResult.fromResult(Ok(5))
+        const res2 = res1.mapErr(() => {
+            expect('to not have been called').toBe(true);
+        });
+        expect(await res2.unwrap()).toEqual(5)
+    });
+
+    it('mapOrElse runs provided mapper on value of Result, and creates new Result', async () => {
+        const res1 = AsyncResult.fromResult(Ok(5))
+        const res2 = res1.mapOrElse(val => val+1, () => { 
+            expect('to not have been called').toBe(true)
+            return 0;
+        });
+        expect(await res1.unwrap()).toEqual(5)
+        expect(await res2.unwrap()).toEqual(6)
+    });
+    it('async mapOrElse runs provided mapper on value of Result, and creates new Result', async () => {
+        const res1 = AsyncResult.fromResult(Ok(5))
+        const res2 = res1.mapOrElse(async val => val+1, () => { 
+            expect('to not have been called').toBe(true)
+            return 0;
+        });
+        expect(await res1.unwrap()).toEqual(5)
+        expect(await res2.unwrap()).toEqual(6)
+    });
+
+    it('mapOrElse runs provided fallback on err of Result, and creates new Ok Result', async () => {
+        const res1 = AsyncResult.fromResult(Err(5))
+        const res2 = res1.mapOrElse(() => { 
+            expect('to not have been called').toBe(true)
+            return 0;
+        }, err => err+1);
+        expect(await res2.unwrap()).toEqual(6)
+    });
+    it('async mapOrElse runs provided fallback on err of Result, and creates new Ok Result', async () => {
+        const res1 = AsyncResult.fromResult(Err(5))
+        const res2 = res1.mapOrElse(() => { 
+            expect('to not have been called').toBe(true)
+            return 0;
+        }, err => err+1);
+        expect(await res2.unwrap()).toEqual(6)
+    });
+});
+
+describe('utils', () => {
+    it('Result toAsync and back', async () => {
+        const res = Ok(1);
+        expect(await res.toAsync().promise).toStrictEqual(res);
+    })
+
+    it('asyncResultify Ok result - calling new function returns AsyncResult', async () => {
+        const test = asyncResultify(async () => 1, () => 1)
+        expect(await test().promise).toEqual(Ok(1));
+    })
+
+    it(
+        'asyncResultify Err result - calling new function returns AsyncResult and errMapper gets applied to result',
+        async () => {
+            const test = asyncResultify(async () => { throw 1; }, () => 'err')
+            expect(await test().promise).toEqual(Err('err'));
+        }
+    )
+
+});

--- a/src/asyncResult.ts
+++ b/src/asyncResult.ts
@@ -1,0 +1,286 @@
+import { Err, Ok, Result } from "./result";
+
+
+/**
+ * Helper class containing promise of a Result. For more ergonomic usage of Results with async code
+ */
+export class AsyncResult<Val, Err> {
+
+    /**
+     * @param promise
+     * @description AsyncResult.fromPromise(promise, mapError) will return AsyncResult containing the promise.
+     * @example
+     * const resPromise = AsyncResult.fromPromise(Promise.resolve(1));
+     * // Type of resPromise is AsyncResult<number, unknown>
+     */
+    static fromPromise<Val>( promise: Promise<Val>): AsyncResult<Val, unknown> {
+        const resultRawPromise: Promise<Result<Val, unknown>> = promise.then(val => Ok(val)).catch(err => Err(err));
+        return new AsyncResult(resultRawPromise);
+    }
+
+    /**
+     * @param result
+     * @description AsyncResult.fromResult(result) will return AsyncResult containing promise of provided result 
+     * @example
+     * const resPromise = AsyncResult.fromResult(Ok(5));
+     * // Type of resPromise is AsyncResult<number, never>
+     */
+    static fromResult<Val, Err>(result: Result<Val, Err>): AsyncResult<Val, Err> {
+        return new AsyncResult(Promise.resolve(result));
+    }
+
+
+    /**
+     * @description Contained promise of Result
+     * @example
+     * const resPromise = AsyncResult.fromPromise(Promise.resolve(1), () => 'string');
+     * const awaited  = await resPromise.promise;
+     * // Type of awaited is Result<number, string>
+     */
+    readonly promise: Promise<Result<Val, Err>>; 
+    constructor(promise: Promise<Result<Val, Err>>) {
+        this.promise = promise;
+    }
+
+    /**
+     * @description returns promise of result value if it's not an error, otherwise throws an exception
+     * @example
+     * let res = AsyncResult.fromResult(Ok(5));
+     * console.log(await res.unwrap()); // 5
+     * 
+     * res = AsyncResult.fromResult(Err('err'));
+     * console.log(await res.unwrap()); // Exception: Tried to unwrap an Error result
+     */
+    async unwrap(): Promise<Val> {
+        return (await this.promise).unwrap();
+    };
+
+    /**
+     * @description returns error value if it exists, otherwise throws an exception
+     * @example
+     * let res = AsyncResult.fromResult(Ok(5));
+     * console.log(await res.unwrapErr()); // Exception: Tried to unwrap Ok result's error
+     * 
+     * res = AsyncResult.fromResult(Err('error msg'));
+     * console.log(await res.unwrapErr()); // 'error msg'
+     */
+    async unwrapErr(): Promise<Err> {
+        return (await this.promise).unwrapErr();
+    }
+
+    /**
+     * @param altVal
+     * @description result.unwrapOr(altVal) will return altVal in case of error
+     * @example
+     * let res = AsyncResult.fromResult(Ok(5));
+     * console.log(await res.unwrapOr(0)); // 5
+     * 
+     * res = AsyncResult.fromResult(Err('error msg'));
+     * console.log(await res.unwrapOr(0)); // 0
+     */
+    async unwrapOr(altVal: Val): Promise<Val> {
+        return (await this.promise).unwrapOr(altVal);
+    }
+
+    /**
+     * @param altValFactory
+     * @description result.unwrapOrElse(altValFactory) will return return value of altValFactory in case of error
+     * @example
+     * let res = AsyncResult.fromResult(Ok(5));
+     * console.log(await res.unwrapOrElse(async () => 0)); // 5
+     * 
+     * res = AsyncResult.fromResult(Err('error msg'));
+     * console.log(await res.unwrapOrElse(async () => 0)); // 0
+     */
+    async unwrapOrElse(altValFactory: (err: Err) => AsyncMapped<Val>): Promise<Val> {
+        const res = await this.promise;
+        if (res.isOk()) {
+            return res.unwrap();
+        }
+        return altValFactory(res.unwrapErr());
+    };
+
+    /**
+     * @param msg
+     * @description result.expect(message) unwrap result or throw new Error with message in case of error
+     * @example
+     * let res = AsyncResult.fromResult(Ok(5));
+     * console.log(await res.expect('provided message')); // 5
+     * 
+     * res = AsyncResult.fromResult(Err('error msg'));
+     * console.log(await res.expect('provided message')); // Exception: provided message
+     */
+    async expect(msg: string): Promise<Val> {
+        return (await this.promise).expect(msg);
+    };
+
+    /**
+     * @param msg
+     * @description result.expectErr(message) unwrap error or throw new Error with message in case of Ok
+     * @example
+     * let res = AsyncResult.fromResult(Ok(5));
+     * console.log(await res.expectErr('provided message')); // Exception: provided message
+     * 
+     * res = AsyncResult.fromResult(Err('error msg'));
+     * console.log(await res.expectErr('provided message')); // 'error msg'
+     */
+    async expectErr(msg: string): Promise<Err> {
+        return (await this.promise).expectErr(msg);
+    };
+
+    /**
+     * @description result.isOk() returns true if Result is Ok or false if result is Err
+     * @example
+     * let res = AsyncResult.fromResult(Ok(5));
+     * console.log(await res.isOk()); // true
+     * 
+     * res = AsyncResult.fromResult(Err('error msg'));
+     * console.log(await res.isOk()); // false
+     */
+    async isOk(): Promise<boolean> {
+        return (await this.promise).isOk();
+    }
+
+    /**
+     * @description result.isErr() returns false if Result is Ok or true if result is Err
+     * @example
+     * let res = AsyncResult.fromResult(Ok(5));
+     * console.log(await res.isErr()); // false
+     * 
+     * res = AsyncResult.fromResult(Err('error msg'));
+     * console.log(await res.isErr()); // true
+     */
+    async isErr(): Promise<boolean> {
+        return (await this.promise).isErr();
+    }
+
+    /**
+     * @description result.ok() returns value of Result if it is Ok, or undefined if it is Err
+     * @example
+     * let res = AsyncResult.fromResult(Ok(5));
+     * console.log(await res.ok()); // 5
+     * 
+     * res = AsyncResult.fromResult(Err('error msg'));
+     * console.log(await res.ok()); // undefined
+     */
+    async ok(): Promise<Val|undefined> {
+        return (await this.promise).ok();
+    }
+
+    /**
+     * @description result.err() returns undefined if Result is Ok, or contained error if Result is Err
+     * @example
+     * let res = AsyncResult.fromResult(Ok(5));
+     * console.log(await res.err()); // undefined
+     * 
+     * res = AsyncResult.fromResult(Err('error msg'));
+     * console.log(await res.err()); // 'error msg'
+     */
+    async err(): Promise<Err|undefined> {
+        return (await this.promise).err();
+    }
+
+    /**
+     * @param inspector
+     * @description result.inspect() will run provided inspector if Result is Ok
+     * @example
+     * let res = AsyncResult.fromResult(Ok(5));
+     * await res.inspect((val) => console.log(`logged ${val}`)).promise; // logged 5
+     * 
+     * res = AsyncResult.fromResult(Err('error msg'));
+     * await res.inspect((val) => console.log(`logged ${val}`)).promise; // <nothing>
+     */
+    inspect(inspector: (val: Val) => any): AsyncResult<Val, Err> {
+        return this.thenInternal(async res => res.inspect(inspector))
+    };
+
+    /**
+     * @param inspector
+     * @description result.inspectErr() will run provided inspector if Result is Err
+     * @example
+     * let res = AsyncResult.fromResult(Ok(5));
+     * await res.inspectErr((val) => console.log(`logged ${val}`)).promise; // <nothing>
+     * 
+     * res = AsyncResult.fromResult(Err('error msg'));
+     * await res.inspectErr((val) => console.log(`logged ${val}`)).promise; // logged error msg
+     */
+    inspectErr(inspector: (err: Err) => any): AsyncResult<Val, Err> {
+        return this.thenInternal(async res => res.inspectErr(inspector))
+    };
+
+    /**
+     * @param mapper
+     * @description result.map(mapper) will run provided mapper with Result value if Result is Ok
+     * @example
+     * let res = AsyncResult.fromResult(Ok(5));
+     * console.log(await res.map((val) => val + 1).unwrap()); // 6
+     */
+    map<NewVal>(mapper: (val: Val) => AsyncMapped<NewVal>): AsyncResult<NewVal, Err> {
+        return this.thenInternal(async (res): Promise<Result<NewVal, Err>> => {
+            if(res.isOk()) {
+                return Ok(await mapper(res.unwrap()))
+            } else {
+                return Err(res.unwrapErr());
+            }
+        });
+    };
+
+    /**
+     * @param mapper
+     * @param fallback
+     * @description result.mapOrElse(mapper, fallback) will run provided mapper with Result value if Result is Ok
+     *              ir run provided fallback with Result error if Result is Err
+     * @example
+     * let res = AsyncResult.fromResult(Ok(5));
+     * console.log(await res.map((val) => val + 1, err => err + ' suffix').unwrap()); // 6
+     * 
+     * res = AsyncResult.fromResult(Err('error msg'));
+     * console.log(await res.map((val) => val + 1, err => err + ' suffix').unwrapErr()); // error msg suffix
+     */
+    mapOrElse<NewVal>(
+        mapper: (val: Val) => AsyncMapped<NewVal>,
+        fallback: (err: Err) => AsyncMapped<NewVal>
+    ): AsyncResult<NewVal, Err> {
+        return this.thenInternal(async (res): Promise<Result<NewVal, Err>> => {
+            if(res.isOk()) {
+                return Ok(await mapper(res.unwrap()))
+            } else {
+                return Ok(await fallback(res.unwrapErr()));
+            }
+        });
+    }
+
+    /**
+     * @param mapper
+     * @description result.mapErr(mapper) will run provided mapper with Result error if Result is Err
+     * @example
+     * let res = AsyncResult.fromResult(Err('error msg'));
+     * console.log(await res.mapErr(err => err + ' suffix').unwrapErr()); // error msg suffix
+     */
+    mapErr<NewErr>(mapper: (err: Err) => AsyncMapped<NewErr>): AsyncResult<Val, NewErr> {
+        return this.thenInternal(async (res): Promise<Result<Val, NewErr>> => {
+            if(res.isOk()) {
+                return Ok(res.unwrap())
+            } else {
+                return Err(await mapper(res.unwrapErr()));
+            }
+        });
+    };
+
+    private thenInternal<NewVal, NewErr>(
+        mapper: (result: Result<Val, Err>) => AsyncMapped<Result<NewVal, NewErr>>
+    ): AsyncResult<NewVal, NewErr> {
+        return new AsyncResult(this.promise.then(mapper));
+    }
+}
+
+type AsyncMapped<T> = T|Promise<T>
+
+type AsyncFn<T> = (...params: any[]) => Promise<T>;
+type AsyncResFn<T, E, F extends AsyncFn<T>> = (...params: Parameters<F>) => AsyncResult<T, E>;
+/**
+ * @description Creates function returning AsyncResult from provided async function and error mapper
+ */
+export function asyncResultify<T, E, F extends AsyncFn<T>>(fn: F, mapErr: (err: unknown) => E): AsyncResFn<T, E, F> {
+    return (...params) => AsyncResult.fromPromise(fn(...params)).mapErr(mapErr);
+}

--- a/src/asyncResult.ts
+++ b/src/asyncResult.ts
@@ -291,8 +291,7 @@ type AsyncMapped<T> = T | Promise<T>
  * };
  * const fn = asyncResultify(
  *     rawFn,
- *     // Thrown exception must be mapped if we want it to have types. Because thrown exception is always unknown.
- *     async err => (err instanceof Error) ? err.message : 'unknown err'
+ *     async err => err.message
  * ); // (a: number) => AsyncResult<number, string>
  * const res = fn(-2); // AsyncResult<number, string>
  * await res.err() // 'not today'

--- a/src/asyncResult.ts
+++ b/src/asyncResult.ts
@@ -1,4 +1,4 @@
-import { ResultCaughtError, thrownUnknownToError } from "./baseResultError";
+import { ResultBaseError, thrownUnknownToBaseError } from "./baseResultError";
 import { Err, Ok, Result } from "./result";
 
 
@@ -15,8 +15,8 @@ export class AsyncResult<Val, Err> {
      * const resPromise = AsyncResult.fromPromise(Promise.resolve(1));
      * // Type of resPromise is AsyncResult<number, unknown>
      */
-    static fromPromise<Val>(promise: Promise<Val>): AsyncResult<Val, ResultCaughtError> {
-        const resultRawPromise: Promise<Result<Val, ResultCaughtError>> = promise.then(val => Ok(val)).catch(err => Err(thrownUnknownToError(err)));
+    static fromPromise<Val>(promise: Promise<Val>): AsyncResult<Val, ResultBaseError> {
+        const resultRawPromise: Promise<Result<Val, ResultBaseError>> = promise.then(val => Ok(val)).catch(err => Err(thrownUnknownToBaseError(err)));
         return new AsyncResult(resultRawPromise);
     }
 
@@ -296,8 +296,8 @@ type AsyncMapped<T> = T | Promise<T>
  * const res = fn(-2); // AsyncResult<number, string>
  * await res.err() // 'not today'
  */
-export function asyncResultify<TRes, TParams extends any[], E = ResultCaughtError>(
-    fn: (...params: TParams) => Promise<TRes>, mapErr?: (err: ResultCaughtError) => AsyncMapped<E>
+export function asyncResultify<TRes, TParams extends any[], E = ResultBaseError>(
+    fn: (...params: TParams) => Promise<TRes>, mapErr?: (err: ResultBaseError) => AsyncMapped<E>
 ): (...params: TParams) => AsyncResult<TRes, E> {
     return (...params: Parameters<typeof fn>) => {
         const asyncPromise = AsyncResult.fromPromise(fn(...params));
@@ -315,6 +315,6 @@ export function asyncResultify<TRes, TParams extends any[], E = ResultCaughtErro
  * const promise = Promise.reject();
  * const result = toAsyncResult(promise);
  */
-export function toAsyncResult<Val>(promise: Promise<Val>): AsyncResult<Val, ResultCaughtError> {
+export function toAsyncResult<Val>(promise: Promise<Val>): AsyncResult<Val, ResultBaseError> {
     return AsyncResult.fromPromise(promise);
 }

--- a/src/baseResultError.ts
+++ b/src/baseResultError.ts
@@ -1,0 +1,45 @@
+
+/**
+ *  @description Type for errors caught by resultify and fromPromise. Thrown non-Error values are converted to Error
+ */
+export type ResultCaughtError = BaseResultError | Error;
+export function thrownUnknownToError(origValue: unknown): ResultCaughtError {
+	if (origValue instanceof Error) {
+		return origValue
+	}
+	return new BaseResultError(origValue);
+
+}
+
+/**
+ *  @description Base class for errors caught by resultify and fromPromise.
+ *               converts non Error values to Error
+ */
+export class BaseResultError extends Error {
+	/**
+	 * @description exotic value that was thrown
+	 */
+	public origValue: unknown;
+
+
+	constructor(origValue?: unknown) {
+		super('');
+
+		this.origValue = origValue;
+		this.name = 'BaseResultError';
+		const type = Array.isArray(origValue) ? 'array' : typeof origValue;
+		this.message = `Caught exotic value (${type})`;
+
+		if (typeof origValue?.toString !== 'function') {
+			return;
+		}
+
+		const newMsg = origValue.toString();
+
+		if (typeof newMsg !== 'string') {
+			return;
+		}
+
+		this.message += `: ${newMsg}`;
+	}
+}

--- a/src/baseResultError.ts
+++ b/src/baseResultError.ts
@@ -7,33 +7,39 @@ export function thrownUnknownToBaseError(origValue: unknown): ResultBaseError {
 	if (origValue instanceof Error) {
 		return origValue
 	}
-
-	const type = Array.isArray(origValue) ? 'array' : typeof origValue;
-	const baseErr: BaseError = {
-		name: 'BaseError',
-		message: `Caught exotic value (${type})`,
-		origValue: origValue
-	}
-	if (typeof origValue?.toString !== 'function') {
-		return baseErr;
-	}
-
-	const newMsg = origValue.toString();
-
-	if (typeof newMsg !== 'string') {
-		return baseErr;
-	}
-
-	baseErr.message += `: ${newMsg}`;
-	return baseErr
+	return new BaseError(origValue);
 }
 
 /**
  *  @description Error-like wrapper for non-Error values caught by resultify and fromPromise.
  */
-interface BaseError extends Error {
+class BaseError implements Error {
+	name = 'BaseError';
+	message: string;
+	stack?: string | undefined;
 	/**
 	 * @description exotic value that was thrown
 	 */
 	origValue: unknown;
+
+	constructor(origValue: unknown) {
+		const type = Array.isArray(origValue) ? 'array' : typeof origValue;
+		this.message = `Caught exotic value (${type})`;
+		this.origValue = origValue;
+		if (typeof origValue?.toString !== 'function') {
+			return;
+		}
+
+		const newMsg = origValue.toString();
+
+		if (typeof newMsg !== 'string') {
+			return;
+		}
+
+		this.message += `: ${newMsg}`;
+	}
+	toString() {
+		return `${this.name}: ${this.message}`;
+	}
+
 }

--- a/src/baseResultError.ts
+++ b/src/baseResultError.ts
@@ -2,7 +2,7 @@
 /**
  *  @description Type for errors caught by resultify and fromPromise. Thrown non-Error values are converted to Error
  */
-export type ResultBaseError = BaseError | Error;
+export type ResultBaseError = Error & { origValue?: unknown };
 export function thrownUnknownToBaseError(origValue: unknown): ResultBaseError {
 	if (origValue instanceof Error) {
 		return origValue

--- a/src/baseResultError.ts
+++ b/src/baseResultError.ts
@@ -2,44 +2,38 @@
 /**
  *  @description Type for errors caught by resultify and fromPromise. Thrown non-Error values are converted to Error
  */
-export type ResultCaughtError = BaseResultError | Error;
-export function thrownUnknownToError(origValue: unknown): ResultCaughtError {
+export type ResultBaseError = BaseError | Error;
+export function thrownUnknownToBaseError(origValue: unknown): ResultBaseError {
 	if (origValue instanceof Error) {
 		return origValue
 	}
-	return new BaseResultError(origValue);
 
+	const type = Array.isArray(origValue) ? 'array' : typeof origValue;
+	const baseErr: BaseError = {
+		name: 'BaseError',
+		message: `Caught exotic value (${type})`,
+		origValue: origValue
+	}
+	if (typeof origValue?.toString !== 'function') {
+		return baseErr;
+	}
+
+	const newMsg = origValue.toString();
+
+	if (typeof newMsg !== 'string') {
+		return baseErr;
+	}
+
+	baseErr.message += `: ${newMsg}`;
+	return baseErr
 }
 
 /**
- *  @description Base class for errors caught by resultify and fromPromise.
- *               converts non Error values to Error
+ *  @description Error-like wrapper for non-Error values caught by resultify and fromPromise.
  */
-export class BaseResultError extends Error {
+interface BaseError extends Error {
 	/**
 	 * @description exotic value that was thrown
 	 */
-	public origValue: unknown;
-
-
-	constructor(origValue?: unknown) {
-		super('');
-
-		this.origValue = origValue;
-		this.name = 'BaseResultError';
-		const type = Array.isArray(origValue) ? 'array' : typeof origValue;
-		this.message = `Caught exotic value (${type})`;
-
-		if (typeof origValue?.toString !== 'function') {
-			return;
-		}
-
-		const newMsg = origValue.toString();
-
-		if (typeof newMsg !== 'string') {
-			return;
-		}
-
-		this.message += `: ${newMsg}`;
-	}
+	origValue: unknown;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
 export * from './result';
+export * from './asyncResult'

--- a/src/result.test.ts
+++ b/src/result.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from '@jest/globals';
 import { Err, Ok, Result, resultify, toResult } from './result';
 
+
 describe('Constructors', () => {
     it('Err fn produces correct Result', () => {
         const errRes = Err('Test err');
@@ -120,7 +121,7 @@ describe('Result methods', () => {
 
 describe('mappers', () => {
     it('inspect gets called with Result value if Result is Ok', () => {
-        let inspected: number|undefined = undefined;
+        let inspected: number | undefined = undefined;
         Ok(5).inspect(val => inspected = val)
         expect(inspected).toEqual(5);
     });
@@ -132,7 +133,7 @@ describe('mappers', () => {
     });
 
     it('inspectErr gets called with Result error if Result is Err', () => {
-        let inspected: number|undefined = undefined;
+        let inspected: number | undefined = undefined;
         Err(5).inspectErr(val => inspected = val)
         expect(inspected).toEqual(5);
     });
@@ -145,7 +146,7 @@ describe('mappers', () => {
 
     it('map runs provided mapper on value of Result, and creates new Result', () => {
         const res1 = Ok(5)
-        const res2 = res1.map(val => val+1);
+        const res2 = res1.map(val => val + 1);
         expect(res1).not.toStrictEqual(res2);
         expect(res1.unwrap()).toEqual(5)
         expect(res2.unwrap()).toEqual(6)
@@ -161,7 +162,7 @@ describe('mappers', () => {
 
     it('mapErr runs provided mapper on err of Result, and creates new Result', () => {
         const res1 = Err(5)
-        const res2 = res1.mapErr(val => val+1);
+        const res2 = res1.mapErr(val => val + 1);
         expect(res1).not.toStrictEqual(res2);
         expect(res1.unwrapErr()).toEqual(5)
         expect(res2.unwrapErr()).toEqual(6)
@@ -177,7 +178,7 @@ describe('mappers', () => {
 
     it('mapOrElse runs provided mapper on value of Result, and creates new Result', () => {
         const res1 = Ok(5)
-        const res2 = res1.mapOrElse(val => val+1, () => expect('to not have been called').toBe(true));
+        const res2 = res1.mapOrElse(val => val + 1, () => expect('to not have been called').toBe(true));
         expect(res1).not.toStrictEqual(res2);
         expect(res1.unwrap()).toEqual(5)
         expect(res2.unwrap()).toEqual(6)
@@ -185,7 +186,7 @@ describe('mappers', () => {
 
     it('mapOrElse runs provided fallback on err of Result, and creates new Ok Result', () => {
         const res1 = Err(5)
-        const res2 = res1.mapOrElse(() => expect('to not have been called').toBe(true), err => err+1);
+        const res2 = res1.mapOrElse(() => expect('to not have been called').toBe(true), err => err + 1);
         expect(res2.unwrap()).toEqual(6)
     });
 });
@@ -201,6 +202,18 @@ describe('utils', () => {
         () => {
             const test = resultify(() => { throw 1; }, () => 'err')
             expect(test()).toEqual(Err('err'));
+        }
+    )
+
+    it(
+        'resultify thrown non-Error err can be accessed',
+        () => {
+            const test = resultify(() => { throw 1; })
+
+            const err = test().unwrapErr();
+            if ('origValue' in err) {
+                expect(err.origValue).toEqual(1);
+            }
         }
     )
 

--- a/src/result.test.ts
+++ b/src/result.test.ts
@@ -1,40 +1,19 @@
 import { describe, expect, it } from '@jest/globals';
-import { Err, Ok, Result, toResult, toResultAsync } from './result';
-
-function timer<T>(val: T): Promise<T> {
-    return new Promise(res => {
-        setTimeout(() => {
-            res(val);
-        }, 100);
-    });
-}
-
-function errTimer(): Promise<never> {
-    return new Promise((_, rej) => {
-        setTimeout(() => {
-            rej();
-        }, 100);
-    });
-}
+import { Err, Ok, Result, resultify, toResult } from './result';
 
 describe('Constructors', () => {
     it('Err fn produces correct Result', () => {
         const errRes = Err('Test err');
-        expect(errRes).toEqual({ value: 'Test err', isError: true });
+        expect(errRes).toEqual({ value: 'Test err' });
     });
 
     it('Ok fn produces correct Result', () => {
         const okRes = Ok('Test res');
-        expect(okRes).toEqual({ isError: false, value: 'Test res' });
+        expect(okRes).toEqual({ value: 'Test res' });
     });
 });
 
 describe('Result methods', () => {
-    it('IsErr returns true in Err results & false in Ok results', () => {
-        expect(Err(true).isError).toBe(true);
-        expect(Ok(true).isError).toBe(false);
-    });
-
     it('Unwrap returns value, if it exists', () => {
         expect(Ok(1).unwrap()).toBe(1);
     });
@@ -43,12 +22,31 @@ describe('Result methods', () => {
         expect(() => Err('err').unwrap()).toThrow();
     });
 
-    it('Expect not trows error, if result not is error', () => {
+    it('UnwrapErr returns error value, if Result is Err', () => {
+        expect(Err(1).unwrapErr()).toBe(1);
+    });
+
+    it('UnwrapErr throws exception, if Result is Ok', () => {
+        expect(() => Ok('no err').unwrapErr()).toThrow();
+    });
+
+    it('Expect does not throw error, if result is Ok', () => {
         expect(() => Ok(3).expect('Should not fail')).not.toThrow();
     });
 
-    it('Expect trows error, if result is error', () => {
-        expect(() => Err('Should fail').expect('Should fail')).toThrowError(new Error('Should fail'));
+    it('Expect throws error, if result is Err', () => {
+        expect(() => Err('Should fail').expect('Should fail')).toThrowErrorMatchingInlineSnapshot(`
+"Should fail
+> Original error is: "Should fail""
+`);
+    });
+
+    it('ExpectErr throws error, if result is Ok', () => {
+        expect(() => Ok(3).expectErr('Should fail')).toThrowError(new Error('Should fail'));
+    });
+
+    it('ExpectErr does not throw error, if result is Err', () => {
+        expect(() => Err('Should not fail').expectErr('Should not fail')).not.toThrow();
     });
 
     it('UnwrapOr returns alt argument if result is error', () => {
@@ -57,6 +55,17 @@ describe('Result methods', () => {
 
     it('UnwrapOr returns alt argument if result is not error', () => {
         expect(Ok(5).unwrapOr(0)).toBe(5);
+    });
+
+    it('UnwrapOrElse does not call altValFactory argument if result is Ok', () => {
+        Ok(5).unwrapOrElse(() => {
+            expect('to not have been called').toBe(true);
+            return 0;
+        });
+    });
+
+    it('UnwrapOrElse returns result of altValFactory argument if result is error', () => {
+        expect(Err('err').unwrapOrElse(() => 4)).toBe(4);
     });
 
     it('UnwrapErr returns value from ERR instance', () => {
@@ -79,19 +88,120 @@ describe('Result methods', () => {
         expect(res.unwrapOr('err')).toBe('err');
     });
 
-    it('ToResultAsync works with resolved promises', async () => {
-        const res = await toResultAsync(() => {
-            return timer(8);
-        });
+    it('isOk returns true if result is Ok', () => {
+        expect(Ok(false).isOk()).toEqual(true)
+    })
+    it('isOk returns false if result is Err', () => {
+        expect(Err(true).isOk()).toEqual(false)
+    })
+    it('isErr returns false if result is Ok', () => {
+        expect(Ok(true).isErr()).toEqual(false)
+    })
+    it('isErr returns true if result is Err', () => {
+        expect(Err(false).isErr()).toEqual(true)
+    })
 
-        expect(res.unwrap()).toBe(8);
+    it('ok returns Result value if result is Ok', () => {
+        expect(Ok(5).ok()).toEqual(5)
     });
 
-    it('ToResultAsync works with rejected promises', async () => {
-        const res = await toResultAsync(() => {
-            return errTimer();
-        });
-
-        expect(res.isError).toBe(true);
+    it('ok returns undefined if result is Err', () => {
+        expect(Err(5).ok()).toEqual(undefined)
     });
+
+    it('err returns Result error if result is Err', () => {
+        expect(Err(5).err()).toEqual(5)
+    });
+
+    it('err returns undefined if result is Ok', () => {
+        expect(Ok(5).err()).toEqual(undefined)
+    });
+});
+
+describe('mappers', () => {
+    it('inspect gets called with Result value if Result is Ok', () => {
+        let inspected: number|undefined = undefined;
+        Ok(5).inspect(val => inspected = val)
+        expect(inspected).toEqual(5);
+    });
+
+    it('inspect does not get called if Result is Err', () => {
+        Err(5).inspect(() => {
+            expect('to not have been called').toBe(true);
+        })
+    });
+
+    it('inspectErr gets called with Result error if Result is Err', () => {
+        let inspected: number|undefined = undefined;
+        Err(5).inspectErr(val => inspected = val)
+        expect(inspected).toEqual(5);
+    });
+
+    it('inspectErr does not get called if Result is Err', () => {
+        Ok(5).inspectErr(() => {
+            expect('to not have been called').toBe(true);
+        })
+    });
+
+    it('map runs provided mapper on value of Result, and creates new Result', () => {
+        const res1 = Ok(5)
+        const res2 = res1.map(val => val+1);
+        expect(res1).not.toStrictEqual(res2);
+        expect(res1.unwrap()).toEqual(5)
+        expect(res2.unwrap()).toEqual(6)
+    });
+
+    it('map does not get run on Err', () => {
+        const res1 = Err(5)
+        const res2 = res1.map(() => {
+            expect('to not have been called').toBe(true);
+        });
+        expect(res2.unwrapErr()).toEqual(5)
+    });
+
+    it('mapErr runs provided mapper on err of Result, and creates new Result', () => {
+        const res1 = Err(5)
+        const res2 = res1.mapErr(val => val+1);
+        expect(res1).not.toStrictEqual(res2);
+        expect(res1.unwrapErr()).toEqual(5)
+        expect(res2.unwrapErr()).toEqual(6)
+    });
+
+    it('mapErr does not get run on Ok', () => {
+        const res1 = Ok(5)
+        const res2 = res1.mapErr(() => {
+            expect('to not have been called').toBe(true);
+        });
+        expect(res2.unwrap()).toEqual(5)
+    });
+
+    it('mapOrElse runs provided mapper on value of Result, and creates new Result', () => {
+        const res1 = Ok(5)
+        const res2 = res1.mapOrElse(val => val+1, () => expect('to not have been called').toBe(true));
+        expect(res1).not.toStrictEqual(res2);
+        expect(res1.unwrap()).toEqual(5)
+        expect(res2.unwrap()).toEqual(6)
+    });
+
+    it('mapOrElse runs provided fallback on err of Result, and creates new Ok Result', () => {
+        const res1 = Err(5)
+        const res2 = res1.mapOrElse(() => expect('to not have been called').toBe(true), err => err+1);
+        expect(res2.unwrap()).toEqual(6)
+    });
+});
+
+describe('utils', () => {
+    it('resultify Ok result - calling new function returns AsyncResult', () => {
+        const test = resultify(() => 1, () => 1)
+        expect(test()).toEqual(Ok(1));
+    })
+
+    it(
+        'resultify Err result - calling new function returns AsyncResult and errMapper gets applied to result',
+        () => {
+            const test = resultify(() => { throw 1; }, () => 'err')
+            expect(test()).toEqual(Err('err'));
+        }
+    )
+
 });

--- a/src/result.ts
+++ b/src/result.ts
@@ -1,5 +1,5 @@
 import { AsyncResult } from "./asyncResult";
-import { ResultCaughtError, thrownUnknownToError } from "./baseResultError";
+import { ResultBaseError, thrownUnknownToBaseError } from "./baseResultError";
 
 export type ResultPromise<T, E> = Promise<Result<T, E>>;
 
@@ -385,15 +385,15 @@ export function toResult<T, E>(fn: () => T): Result<T, E> {
  * const res = fn(-2); // Result<number, string>
  * res.err() // 'not today'
  */
-export function resultify<TRes, TParams extends any[], E = ResultCaughtError>(
-    fn: (...params: TParams) => TRes, mapErr?: (err: ResultCaughtError) => E
+export function resultify<TRes, TParams extends any[], E = ResultBaseError>(
+    fn: (...params: TParams) => TRes, mapErr?: (err: ResultBaseError) => E
 ): (...params: TParams) => Result<TRes, E> {
     return (...params: Parameters<typeof fn>) => {
         try {
             const val = fn(...params);
             return Ok(val);
         } catch (err) {
-            const wrappedErr = thrownUnknownToError(err);
+            const wrappedErr = thrownUnknownToBaseError(err);
             if (mapErr) {
                 return Err(mapErr(wrappedErr));
             }

--- a/src/result.ts
+++ b/src/result.ts
@@ -380,8 +380,7 @@ export function toResult<T, E>(fn: () => T): Result<T, E> {
  * };
  * const fn = resultify(
  *     rawFn,
- *     // Thrown exception must be mapped if we want it to have types. Because thrown exception is always unknown.
- *     err => (err instanceof Error) ? err.message : 'unknown err'
+ *     err => err.message
  * ); // (a: number) => Result<number, string>
  * const res = fn(-2); // Result<number, string>
  * res.err() // 'not today'

--- a/src/result.ts
+++ b/src/result.ts
@@ -1,5 +1,6 @@
+import { AsyncResult } from "./asyncResult";
+
 export interface Result<Val, Err> {
-    readonly isError: boolean;
     readonly value: Val | Err;
 
     /**
@@ -17,7 +18,7 @@ export interface Result<Val, Err> {
      * @description returns error value if it exists, otherwise throws an exception
      * @example
      * let res = Ok(5);
-     * console.log(res.unwrapErr()); // Exception: Tried to unwrap an Ok result error
+     * console.log(res.unwrapErr()); // Exception: Tried to unwrap Ok result's error
      * 
      * res = Err('error msg');
      * console.log(res.unwrapErr()); // 'error msg'
@@ -26,7 +27,7 @@ export interface Result<Val, Err> {
 
     /**
      * @param altVal
-     * @description result.unwrap() will return altVal in case of error
+     * @description result.unwrapOr(altVal) will return altVal in case of error
      * @example
      * let res = Ok(5);
      * console.log(res.unwrapOr(0)); // 5
@@ -36,36 +37,238 @@ export interface Result<Val, Err> {
      */
     unwrapOr(altVal: Val): Val;
 
+    /**
+     * @param altValFactory
+     * @description result.unwrapOrElse(altValFactory) will return return value of altValFactory in case of error
+     * @example
+     * let res = Ok(5);
+     * console.log(res.unwrapOrElse(() => 0)); // 5
+     * 
+     * res = Err('error msg');
+     * console.log(res.unwrapOrElse(() => 0)); // 0
+     */
+    unwrapOrElse(altValFactory: (err: Err) => Val): Val;
+
+    /**
+     * @param msg
+     * @description result.expect(message) unwrap result or throw new Error with message in case of error
+     * @example
+     * let res = Ok(5);
+     * console.log(res.expect('provided message')); // 5
+     * 
+     * res = Err('error msg');
+     * console.log(res.expect('provided message')); // Exception: provided message
+     */
     expect(msg: string): Val;
+
+    /**
+     * @param msg
+     * @description result.expectErr(message) unwrap error or throw new Error with message in case of Ok
+     * @example
+     * let res = Ok(5);
+     * console.log(res.expectErr('provided message')); // Exception: provided message
+     * 
+     * res = Err('error msg');
+     * console.log(res.expectErr('provided message')); // 'error msg'
+     */
+    expectErr(msg: string): Err;
+
+    /**
+     * @description result.isOk() returns true if Result is Ok or false if result is Err
+     * @example
+     * let res = Ok(5);
+     * console.log(res.isOk()); // true
+     * 
+     * res = Err('error msg');
+     * console.log(res.isOk()); // false
+     */
+    isOk(): this is OK<Val>;
+
+    /**
+     * @description result.isErr() returns false if Result is Ok or true if result is Err
+     * @example
+     * let res = Ok(5);
+     * console.log(res.isErr()); // false
+     * 
+     * res = Err('error msg');
+     * console.log(res.isErr()); // true
+     */
+    isErr(): this is ERR<Err>;
+
+    /**
+     * @description result.ok() returns value of Result if it is Ok, or undefined if it is Err
+     * @example
+     * let res = Ok(5);
+     * console.log(res.ok()); // 5
+     * 
+     * res = Err('error msg');
+     * console.log(res.ok()); // undefined
+     */
+    ok(): Val|undefined,
+
+    /**
+     * @description result.err() returns undefined if Result is Ok, or contained error if Result is Err
+     * @example
+     * let res = Ok(5);
+     * console.log(res.err()); // undefined
+     * 
+     * res = Err('error msg');
+     * console.log(res.err()); // 'error msg'
+     */
+    err(): Err|undefined,
+
+    /**
+     * @param inspector
+     * @description result.inspect() will run provided inspector if Result is Ok
+     * @example
+     * let res = Ok(5);
+     * res.inspect((val) => console.log(`logged ${val}`)); // logged 5
+     * 
+     * res = Err('error msg');
+     * res.inspect((val) => console.log(`logged ${val}`)); // <nothing>
+     */
+    inspect(inspector: (val: Val) => any): Result<Val, Err>;
+
+    /**
+     * @param inspector
+     * @description result.inspectErr() will run provided inspector if Result is Err
+     * @example
+     * let res = Ok(5);
+     * res.inspectErr((val) => console.log(`logged ${val}`)); // <nothing>
+     * 
+     * res = Err('error msg');
+     * res.inspectErr((val) => console.log(`logged ${val}`)); // logged error msg
+     */
+    inspectErr(inspector: (err: Err) => any): Result<Val, Err>;
+
+    /**
+     * @param mapper
+     * @description result.map(mapper) will run provided mapper with Result value if Result is Ok
+     * @example
+     * let res = Ok(5);
+     * console.log(res.map((val) => val + 1).unwrap()); // 6
+     */
+    map<MappedVal>(mapper: (val: Val) => MappedVal): Result<MappedVal, Err>;
+
+    /**
+     * @param mapper
+     * @param fallback
+     * @description result.mapOrElse(mapper, fallback) will run provided mapper with Result value if Result is Ok
+     *              ir run provided fallback with Result error if Result is Err
+     * @example
+     * let res = Ok(5);
+     * console.log(res.map((val) => val + 1, err => err + ' suffix').unwrap()); // 6
+     * 
+     * res = Err('error msg');
+     * console.log(res.map((val) => val + 1, err => err + ' suffix').unwrapErr()); // error msg suffix
+     */
+    mapOrElse<MappedVal>(mapper: (val: Val) => MappedVal, fallback: (err: Err) => MappedVal): Result<MappedVal, Err>;
+
+    /**
+     * @param mapper
+     * @description result.mapErr(mapper) will run provided mapper with Result error if Result is Err
+     * @example
+     * let res = Err('error msg');
+     * console.log(res.mapErr(err => err + ' suffix').unwrapErr()); // error msg suffix
+     */
+    mapErr<MappedErr>(mapper: (err: Err) => MappedErr): Result<Val, MappedErr>;
+
+    toAsync(): AsyncResult<Val, Err>;
 }
 
+const origErrorPrefix = '> ';
 class ERR<Err> implements Result<never, Err> {
-    isError = true;
     public readonly value!: Err;
 
     constructor(value: Err) {
         this.value = value;
     }
 
-    unwrap<Res>(): Res {
-        throw new Error('Tried to unwrap an Error result');
+    private throwError(msg: string): never {
+        throw new Error(msg + '\n' + this.getAdditionalErrorMessage());
+    }
+
+    private getAdditionalErrorMessage() {
+        if (this.value instanceof Error) {
+            const origErrStack = this.value.stack?.split('\n').map(line => origErrorPrefix+line).join('\n')
+            return origErrorPrefix+'Original error:\n' + origErrStack
+        }
+        if (typeof this.value === 'object') {
+            return origErrorPrefix+'Original error is object';
+        }
+        if (typeof this.value === 'number') {
+            return origErrorPrefix+`Original error is: ${this.value}`;
+        }
+        if (typeof this.value === 'string') {
+            return origErrorPrefix+`Original error is: "${this.value}"`;
+        }
+    }
+
+    unwrap(): never {
+        this.throwError('Tried to unwrap an Error result');
     }
 
     unwrapOr<Res>(alt: Res): Res {
         return alt;
     }
+    unwrapOrElse<Res>(altValFactory: (err: Err) => Res): Res {
+        return altValFactory(this.value);
+    };
 
-    expect<Res>(msg: string): Res {
-        throw new Error(msg);
+    expect(msg: string): never {
+        this.throwError(msg);
+    }
+    expectErr(_msg: string): Err {
+        return this.value;
     }
 
     unwrapErr(): Err {
         return this.value;
     }
+
+    isOk(): false {
+        return false;
+    }
+
+    isErr(): true {
+        return true;
+    }
+
+    ok(): undefined {
+        return undefined;
+    }
+
+    err(): Err {
+        return this.value
+    }
+
+    inspect(_inspector: (val: never) => any): Result<never, Err> {
+        return this as unknown as Result<never, Err>;
+    }
+
+    inspectErr(inspector: (err: Err) => any): Result<never, Err> {
+        inspector(this.value);
+        return Err(this.value);
+    }
+
+    map(_mapper: (val: never) => any): Result<never, Err> {
+        return Err(this.value);
+    }
+
+    mapOrElse<MappedVal>(_mapper: any, fallback: (err: Err) => MappedVal): Result<MappedVal, never> {
+        return Ok(fallback(this.value))
+    }
+
+    mapErr<MappedErr>(mapper: (err: Err) => MappedErr): Result<never, MappedErr> {
+        return Err(mapper(this.value))
+    }
+
+    toAsync(this: Result<never, Err>): AsyncResult<never, Err> {
+        return AsyncResult.fromResult(this);
+    }
 }
 
 class OK<Val> implements Result<Val, never> {
-    isError = false;
     readonly value!: Val;
 
     constructor(value: Val) {
@@ -79,13 +282,60 @@ class OK<Val> implements Result<Val, never> {
     unwrapOr(_val: Val): Val {
         return this.value;
     }
+    unwrapOrElse(_altValFactory: (err: never) => Val): Val {
+        return this.value;
+    };
 
     expect(_msg: string): Val {
         return this.value;
     }
+    expectErr(msg: string): never {
+        throw new Error(msg);
+    }
 
     unwrapErr(): never {
         throw new Error('Tried to unwrap Ok result\'s error');
+    }
+
+    isOk(): true {
+        return true;
+    }
+
+    isErr(): false {
+        return false;
+    }
+
+    ok(): Val {
+        return this.value;
+    }
+
+    err(): undefined {
+        return undefined;
+    }
+
+    inspect(inspector: (val: Val) => any): Result<Val, never> {
+        inspector(this.value);
+        return Ok(this.value)
+    }
+
+    inspectErr(_inspector: (err: never) => any): Result<Val, never> {
+        return Ok(this.value)
+    }
+
+    map<MappedVal>(mapper: (val: Val) => MappedVal): Result<MappedVal, never> {
+        return Ok(mapper(this.value));
+    }
+
+    mapOrElse<MappedVal>(mapper: (val: Val) => MappedVal, _fallback: (err: never) => any ): Result<MappedVal, never> {
+        return Ok(mapper(this.value));
+    }
+
+    mapErr<MappedErr>(_mapper: (err: never) => any): Result<Val, MappedErr> {
+        return Ok(this.value)
+    }
+    
+    toAsync(this: Result<Val, never>): AsyncResult<Val, never> {
+        return AsyncResult.fromResult(this);
     }
 }
 
@@ -115,19 +365,21 @@ export function toResult<T, E>(fn: () => T): Result<T, E> {
     }
 }
 
-export async function toResultAsync<T, E>(tg: Promise<T> | (() => Promise<T>)): Promise<Result<T, E>> {
-    if (typeof tg !== 'function' && typeof tg !== 'object') {
-        throw new Error('toResultAsync accepts only promises or functions that return a promise');
+type Fn<T> = (...params: any[]) => T;
+type ResFn<T, E, F extends Fn<T>> = (...params: Parameters<F>) => Result<T, E>;
+/**
+ * @description Catches exceptions and converts them into Result
+*/
+export function resultify<T, E, F extends Fn<T>>(fn: F, mapErr: (err: unknown) => E): ResFn<T, E, F> {
+    return (...params) => { 
+        try {
+            const val = fn(...params);
+            return Ok(val);
+        } catch(e) {
+            return Err(mapErr(e));
+        }
     }
-
-    const promise = typeof tg === 'object' ? tg : tg();
-
-    return promise.then((val) => {
-        return Ok(val);
-    })
-    .catch(err => {
-        return Err(err);
-    });
 }
 
-export type AsyncResult<Val, Err> = Promise<Result<Val, Err>>;
+export type Ok<T> = OK<T>;
+export type Err<T> = ERR<T>;


### PR DESCRIPTION
Hello, I may went a little overboard with this contribution. 

I had some conflicts of functionality/naming and considered deprecating original code, but the naming conflict was not really solvable (can't come up with any other good name than AsyncResult) so I decided to go for full replacement instead of deprecation. These conflicts are:

1. `.isError` -> `.isErr()` because I was not able to make type narrowing work with simple property.
2. type `AsyncResult` -> class `AsyncResult` because just wrapping `Result` with Promise is not good enough.
3. removed `toResultAsync` in favor of new `AsyncResult.fromPromise`

For this reason this PR aims for new major version of this package.

This PR adds many functionalities inspired by Rust Result, and also adds whole new class to make dealing with async Results a pleasure.

I am looking forward to your feedback.