### PR TITLE
createAsyncResultFn and better error reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,14 +76,16 @@ class ERR implements Result;
 Class that contains operation result and interaction methods for async code
 ``` ts
 type AsyncMapped<T> = T|Promise<T>
+type PromiseResult<T, E> = Promise<Result<T, E>>
 // Async result implementation for more ergonomic usage of Results with async code
 class AsyncResult<Val, Err> {
     // Contained promise
-    promise: Promise<Result<Val, Err>>; 
+    promise: PromiseResult<Val, Err>; 
 
     // Creators
     static fromPromise<Val>(promise: Promise<Val>): AsyncResult<Val, unknown>;
     static fromResult<Val, Err>(result: Result<Val, Err>): AsyncResult<Val, Err>;
+    static fromResultPromise<Val, Err>(result: PromiseResult<Val, Err>): AsyncResult<Val, Err>;
 
     // Queries
     async unwrap(): Promise<Val>;
@@ -127,6 +129,11 @@ function resultify<TRes, TParams extends any[], E = ResultBaseError>(
 function asyncResultify<TRes, TParams extends any[], E = ResultBaseError>(
     fn: (...params: TParams) => Promise<TRes>, mapErr?: (err: ResultBaseError) => AsyncMapped<E>
 ): (...params: TParams) => AsyncResult<TRes, E>
+
+// Create function returning AsyncResult instead of ResultPromise, for more convenient result consumption
+function createAsyncResultFn<TRes, TParams extends any[], E>(
+    fn: (...params: TParams) => ResultPromise<TRes, E>,
+): (...params: TParams) => AsyncResult<TRes, E> {
 ```
 
 ## Example

--- a/src/asyncResult.test.ts
+++ b/src/asyncResult.test.ts
@@ -92,7 +92,7 @@ describe('Result methods', () => {
         expect(asyncErrRes.unwrap()).rejects.toThrow();
         expect(asyncErrRes.expect('err')).rejects.toThrowErrorMatchingInlineSnapshot(`
 "err
-> Original error is: 1"
+    Original error is: 1"
 `);
     });
 });

--- a/src/asyncResult.test.ts
+++ b/src/asyncResult.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from '@jest/globals';
 import { Err, Ok } from './result';
 
-import { AsyncResult, asyncResultify } from './asyncResult';
+import { AsyncResult, asyncResultify, createAsyncResultFn } from './asyncResult';
 
 describe('Constructors', () => {
     it('Simple Ok async result constructed from Ok result resolves to the provided result', async () => {
@@ -23,7 +23,7 @@ describe('Constructors', () => {
 
     it(
         'Simple Err async result constructed from promise of errRes which rejects with non-Error value, ' +
-            'resolves to Err of the value wrapped with BaseResultError',
+        'resolves to Err of the value wrapped with BaseResultError',
         async () => {
             const res = await AsyncResult.fromPromise(Promise.reject(1)).promise;
             expect(res.unwrapErr().toString()).toMatchInlineSnapshot(`"BaseError: Caught exotic value (number): 1"`);
@@ -31,7 +31,7 @@ describe('Constructors', () => {
     );
     it(
         'Simple Err async result constructed from promise of errRes which rejects with Error value, ' +
-            'resolves to Err of the value',
+        'resolves to Err of the value',
         async () => {
             const res = await AsyncResult.fromPromise(Promise.reject(new Error('err'))).promise;
             expect(res).toEqual(Err(new Error('err')));
@@ -246,4 +246,18 @@ describe('utils', () => {
 
         expect(await test().promise).toEqual(Err('err'));
     });
+
+    it(
+        'createAsyncResultFn correctly creates function returning AsyncResult from fn returning ResultPromise',
+        async () => {
+            const test = createAsyncResultFn(async (num: number) => {
+                if (num >= 0) {
+                    return Ok(num);
+                }
+                return Err('err');
+            })
+
+            expect(await test(5).promise).toEqual(Ok(5));
+            expect(await test(-1).promise).toEqual(Err('err'));
+        });
 });

--- a/src/baseResultError.ts
+++ b/src/baseResultError.ts
@@ -2,12 +2,25 @@
  *  @description Type for errors caught by resultify and fromPromise. Thrown non-Error values are converted to Error
  */
 export type ResultBaseError = Error & { origValue?: unknown };
+const isResultBaseError = (val: unknown): val is ResultBaseError => {
+    if (!val || typeof val !== 'object') {
+        return false;
+    }
+    if (('message' in val) && ('name' in val) && val.toString !== Object.prototype.toString) {
+        return true;
+    }
+    return false;
+}
 export function thrownUnknownToBaseError(origValue: unknown): ResultBaseError {
     if (origValue instanceof Error) {
         return origValue;
     }
+    if (isResultBaseError(origValue)) {
+        return origValue;
+    }
     return new BaseError(origValue);
 }
+
 
 /**
  *  @description Error-like wrapper for non-Error values caught by resultify and fromPromise.


### PR DESCRIPTION
Hello, I've had some poor experience using the library due to two reasons.

1. Creating AsyncResult from async functions returning Result is currently very awkward. 
2. Errors from other libraries, which satisfy Error interface but do not extend Error get wrapped in BaseResultError. When that is an object, it prints nothing-telling message.

This PR improves both points.